### PR TITLE
Bugfix/layout transition and redundant loading screen

### DIFF
--- a/app/src/main/java/dk/shape/games/notifications/demo/notifications/SubjectNotificationsDependencyProvider.kt
+++ b/app/src/main/java/dk/shape/games/notifications/demo/notifications/SubjectNotificationsDependencyProvider.kt
@@ -11,7 +11,6 @@ class SubjectNotificationsDependencyProvider : ConfigProvider<SubjectNotificatio
     override fun config(fragment: Fragment): SubjectNotificationsConfig {
         return SubjectNotificationsConfig(
             provideDeviceId = SubjectDeviceIdProviderMock::provideDeviceIdMock,
-            hasCachedConfigData = { false },
             provideNotifications = SubjectNotificationsProviderMock::provideNotificationsMock,
             notificationsDataSource = SubjectNotificationsRepositoryMock,
             eventHandler = SubjectNotificationsEventHandlerMock

--- a/notifications/src/main/java/dk/shape/games/notifications/aliases/SubjectNotificationAliases.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/aliases/SubjectNotificationAliases.kt
@@ -9,5 +9,6 @@ internal typealias SelectionStateNotifier = (isSelected: Boolean, identifier: Su
 internal typealias NotificationsLoadedListener = (
     activatedTypes: Set<SubjectNotificationType>,
     possibleTypes: Set<SubjectNotificationType>,
-    defaultTypes: Set<SubjectNotificationIdentifier>
+    defaultTypes: Set<SubjectNotificationIdentifier>,
+    isSkeleton: Boolean
 ) -> Unit

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
@@ -15,7 +15,7 @@ import dk.shape.games.notifications.repositories.SubjectNotificationsDataSource
  * subscriptions data.
  *
  * @param eventHandler An event handler used for listening to events propagated directly from the
- * noticications component/interactor. The event handle will notifiy upon various events.
+ * notifications component/interactor. The event handle will notifiy upon various events.
  *
  * @see SubjectNotificationsDataSource
  * @see SubjectNotificationsEventHandler

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
@@ -11,10 +11,6 @@ import dk.shape.games.notifications.repositories.SubjectNotificationsDataSource
  * @param provideNotifications Lambda function which returns a list containing notification
  * information for differnt sports.
  *
- * @param hasCachedConfigData Lambda function which returns a boolean indicating whether or not
- * the app configuration data from which the notifications data is retrieved is currrently cahced
- * and readily available. If the data is must be fetch this should return false.
- *
  * @param notificationsDataSource The data source (repository) used for interfacing with the
  * subscriptions data.
  *
@@ -30,8 +26,6 @@ data class SubjectNotificationsConfig(
     val provideDeviceId: suspend () -> String,
 
     val provideNotifications: suspend () -> List<SubjectNotificationGroup>,
-
-    val hasCachedConfigData: () -> Boolean,
 
     val notificationsDataSource: SubjectNotificationsDataSource,
 

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
@@ -9,7 +9,7 @@ import dk.shape.games.notifications.repositories.SubjectNotificationsDataSource
  * @param provideDeviceId Lambda function which returns an UUID (device ID) for the device.
  *
  * @param provideNotifications Lambda function which returns a list containing notification
- * information for differnt sports.
+ * information for different sports.
  *
  * @param notificationsDataSource The data source (repository) used for interfacing with the
  * subscriptions data.

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsConfig.kt
@@ -3,6 +3,28 @@ package dk.shape.games.notifications.presentation
 import dk.shape.games.notifications.aliases.SubjectNotificationGroup
 import dk.shape.games.notifications.repositories.SubjectNotificationsDataSource
 
+/**
+ * Configuration used for for configuring the BottomSheetNotifications fragment.
+ *
+ * @param provideDeviceId Lambda function which returns an UUID (device ID) for the device.
+ *
+ * @param provideNotifications Lambda function which returns a list containing notification
+ * information for differnt sports.
+ *
+ * @param hasCachedConfigData Lambda function which returns a boolean indicating whether or not
+ * the app configuration data from which the notifications data is retrieved is currrently cahced
+ * and readily available. If the data is must be fetch this should return false.
+ *
+ * @param notificationsDataSource The data source (repository) used for interfacing with the
+ * subscriptions data.
+ *
+ * @param eventHandler An event handler used for listening to events propagated directly from the
+ * noticications component/interactor. The event handle will notifiy upon various events.
+ *
+ * @see SubjectNotificationsDataSource
+ * @see SubjectNotificationsEventHandler
+ * @see SubjectNotificationGroup
+ */
 data class SubjectNotificationsConfig(
 
     val provideDeviceId: suspend () -> String,

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsInteractor.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/SubjectNotificationsInteractor.kt
@@ -15,7 +15,6 @@ import java.util.*
 
 class SubjectNotificationsInteractor(
     private val action: SubjectNotificationsAction,
-    private val hasCachedConfigData: () -> Boolean,
     private val provideDeviceId: suspend () -> String,
     private val notificationsProvider: suspend () -> List<SubjectNotificationGroup>,
     private val notificationsDataSource: SubjectNotificationsDataSource,
@@ -30,10 +29,6 @@ class SubjectNotificationsInteractor(
         it.sportId == action.sportId
     }
 
-    override suspend fun hasSupportForSport(): Boolean {
-        return if (hasCachedConfigData()) notificationsProvider().any(sportsIdFilter) else false
-    }
-
     override suspend fun loadNotificationsSkeleton(
         onLoaded: NotificationsLoadedListener
     ) {
@@ -44,7 +39,7 @@ class SubjectNotificationsInteractor(
             val possibleNotificationTypes = notificationsGroup.notificationTypes.toSet()
 
             withContext(Dispatchers.Main) {
-                onLoaded(emptySet(), possibleNotificationTypes, emptySet())
+                onLoaded(emptySet(), possibleNotificationTypes, emptySet(), true)
             }
         }
     }
@@ -87,7 +82,8 @@ class SubjectNotificationsInteractor(
                             onLoaded(
                                 enabledNotificationTypes,
                                 possibleNotificationTypes,
-                                defaultIdentifiers
+                                defaultIdentifiers,
+                                false
                             )
                         }
                     } else {

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationSwitcherViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationSwitcherViewModel.kt
@@ -28,19 +28,15 @@ internal class SubjectNotificationSwitcherViewModel(
     )
 
     val item: ObservableField<Any> = ObservableField<Any>(loadingViewModel).onChange {
-        if (it is SubjectNotificationViewModel.Content) {
-            if (lastViewModel !is SubjectNotificationViewModel.Skeleton) {
-                onItemChanged()
-            }
+        if (it is SubjectNotificationViewModel.Content && lastViewModel !is SubjectNotificationViewModel.Skeleton) {
+            onItemChanged()
         }
         lastViewModel = it
     }
 
     fun showContent(viewModel: SubjectNotificationViewModel) {
-        if (viewModel is SubjectNotificationViewModel.Skeleton) {
-            if (item.get() !is SubjectNotificationViewModel.Content) {
-                item.set(viewModel)
-            }
+        if (viewModel is SubjectNotificationViewModel.Skeleton && item.get() !is SubjectNotificationViewModel.Content) {
+            item.set(viewModel)
         } else {
             item.set(viewModel)
         }

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationSwitcherViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationSwitcherViewModel.kt
@@ -35,8 +35,10 @@ internal class SubjectNotificationSwitcherViewModel(
     }
 
     fun showContent(viewModel: SubjectNotificationViewModel) {
-        if (viewModel is SubjectNotificationViewModel.Skeleton && item.get() !is SubjectNotificationViewModel.Content) {
-            item.set(viewModel)
+        if (viewModel is SubjectNotificationViewModel.Skeleton) {
+            if (item.get() !is SubjectNotificationViewModel.Content) {
+                item.set(viewModel)
+            }
         } else {
             item.set(viewModel)
         }

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationSwitcherViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationSwitcherViewModel.kt
@@ -12,8 +12,9 @@ import me.tatarka.bindingcollectionadapter2.itembindings.OnItemBindClass
 internal class SubjectNotificationSwitcherViewModel(
     val onItemChanged: () -> Unit
 ) {
-
     private val loadingViewModel = LoadingViewModel()
+
+    private var lastViewModel: Any = loadingViewModel
 
     val itemBinding: ItemBinding<Any> = ItemBinding.of(
         OnItemBindClass<Any>()
@@ -26,12 +27,23 @@ internal class SubjectNotificationSwitcherViewModel(
             )
     )
 
-    val item: ObservableField<Any> = ObservableField<Any>().onChange {
-        onItemChanged()
+    val item: ObservableField<Any> = ObservableField<Any>(loadingViewModel).onChange {
+        if (it is SubjectNotificationViewModel.Content) {
+            if (lastViewModel !is SubjectNotificationViewModel.Skeleton) {
+                onItemChanged()
+            }
+        }
+        lastViewModel = it
     }
 
     fun showContent(viewModel: SubjectNotificationViewModel) {
-        item.set(viewModel)
+        if (viewModel is SubjectNotificationViewModel.Skeleton) {
+            if (item.get() !is SubjectNotificationViewModel.Content) {
+                item.set(viewModel)
+            }
+        } else {
+            item.set(viewModel)
+        }
     }
 
     fun showLoading() {

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/SubjectNotificationViewModel.kt
@@ -11,12 +11,12 @@ import dk.shape.games.notifications.bindings.value
 import dk.shape.games.notifications.entities.SubjectType
 import dk.shape.games.notifications.presentation.SubjectNotificationStateData
 
-internal data class SubjectNotificationViewModel(
-    val subjectId: String,
-    val subjectName: String,
-    val subjectType: SubjectType,
-    private val onClosedPressed: () -> Unit,
-    private val onPreferencesSaved: PreferencesSaveAction
+internal sealed class SubjectNotificationViewModel(
+    open val subjectId: String,
+    open val subjectName: String,
+    open val subjectType: SubjectType,
+    protected open val onClosedPressed: () -> Unit,
+    protected open val onPreferencesSaved: PreferencesSaveAction
 ) {
     val hasStateChanges: ObservableBoolean = ObservableBoolean(false)
     val isSavingPreferences: ObservableBoolean = ObservableBoolean(false)
@@ -81,4 +81,24 @@ internal data class SubjectNotificationViewModel(
 
         hasStateChanges.awareSet(hasChanges)
     }
+
+    class Content(
+        subjectId: String,
+        subjectName: String,
+        subjectType: SubjectType,
+        onClosedPressed: () -> Unit,
+        onPreferencesSaved: PreferencesSaveAction
+    ): SubjectNotificationViewModel(
+        subjectId, subjectName, subjectType, onClosedPressed, onPreferencesSaved
+    )
+
+    class Skeleton(
+        subjectId: String,
+        subjectName: String,
+        subjectType: SubjectType,
+        onClosedPressed: () -> Unit,
+        onPreferencesSaved: PreferencesSaveAction
+    ): SubjectNotificationViewModel(
+        subjectId, subjectName, subjectType, onClosedPressed, onPreferencesSaved
+    )
 }

--- a/notifications/src/main/java/dk/shape/games/notifications/usecases/SubjectNotificationUseCases.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/usecases/SubjectNotificationUseCases.kt
@@ -7,9 +7,6 @@ import dk.shape.games.notifications.presentation.SubjectNotificationStateData
 internal interface SubjectNotificationUseCases {
 
     @WorkerThread
-    suspend fun hasSupportForSport(): Boolean
-
-    @WorkerThread
     suspend fun loadNotifications(
         onLoaded: NotificationsLoadedListener,
         onFailure: (error: Throwable) -> Unit  = { }


### PR DESCRIPTION
This approach works in the following way. When we create the fragment we fetch the skeleton data (The notification configuration) If the data is not available onResume a loading indicator is shown otherwise we just show the content.

* Fixes issue where we animate irrelevant state changes
* Only shows the loading screen if we do not have skeleton data
* Removes unnecessary added dependency