### PR TITLE
notifications/settings: toggling back on should enable all if default is empty

### DIFF
--- a/notifications/src/main/java/dk/shape/games/notifications/extensions/LegacyNotificationGroupExtensions.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/extensions/LegacyNotificationGroupExtensions.kt
@@ -1,0 +1,10 @@
+package dk.shape.games.notifications.extensions
+
+import dk.shape.games.notifications.aliases.LegacyNotificationGroup
+
+internal fun LegacyNotificationGroup.toDefaultOrAllNotifications(): Set<String> =
+    defaultNotificationTypeIdentifiers.toSet().let { defaultTypeIds ->
+        if (defaultTypeIds.isEmpty()) {
+            notificationTypes.toIds()
+        } else defaultTypeIds
+    }

--- a/notifications/src/main/java/dk/shape/games/notifications/extensions/LegacyNotificationTypeExtensions.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/extensions/LegacyNotificationTypeExtensions.kt
@@ -6,3 +6,8 @@ internal fun LegacyNotificationType.isChecked(selectedTypeIds: Set<String>) =
     selectedTypeIds.any { typeId ->
         this.identifier == typeId
     }
+
+internal fun List<LegacyNotificationType>.toIds(): Set<String> =
+    map {
+        it.identifier
+    }.toSet()

--- a/notifications/src/main/java/dk/shape/games/notifications/extensions/SubjectNotificationGroupExtensions.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/extensions/SubjectNotificationGroupExtensions.kt
@@ -3,5 +3,9 @@ package dk.shape.games.notifications.extensions
 import dk.shape.games.notifications.aliases.SubjectNotificationGroup
 import dk.shape.games.notifications.aliases.SubjectNotificationType
 
-internal fun SubjectNotificationGroup.toDefaultNotificationTypes(): Set<SubjectNotificationType> =
-    defaultNotificationTypeIdentifiers.toNotificationTypes(notificationTypes)
+internal fun SubjectNotificationGroup.toDefaultOrAllNotificationTypes(): Set<SubjectNotificationType> =
+    defaultNotificationTypeIdentifiers.toNotificationTypes(notificationTypes).let { defaultTypes ->
+        if (defaultTypes.isEmpty()) {
+            notificationTypes.toSet()
+        } else defaultTypes
+    }

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/settings/NotificationsSettingsEventViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/settings/NotificationsSettingsEventViewModel.kt
@@ -6,6 +6,7 @@ import androidx.databinding.ObservableBoolean
 import androidx.databinding.ObservableField
 import dk.shape.games.notifications.actions.NotificationSettingsEventAction
 import dk.shape.games.notifications.aliases.LegacyNotificationGroup
+import dk.shape.games.notifications.extensions.toDefaultOrAllNotifications
 import dk.shape.games.sportsbook.offerings.modules.event.data.Event
 import dk.shape.games.sportsbook.offerings.modules.notification.Subscription
 import dk.shape.games.notifications.extensions.toEventInfo
@@ -70,7 +71,7 @@ data class NotificationsSettingsEventViewModel(
     private fun toggleNotifications(isChecked: Boolean) {
         setNotificationsAsync(
             notificationTypeIds = if (isChecked) {
-                notificationGroup.defaultNotificationTypeIdentifiers.toSet()
+                notificationGroup.toDefaultOrAllNotifications()
             } else emptySet()
         )
     }

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/settings/NotificationsSettingsSubjectViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/settings/NotificationsSettingsSubjectViewModel.kt
@@ -9,7 +9,7 @@ import dk.shape.games.notifications.aliases.SubjectNotificationGroup
 import dk.shape.games.notifications.aliases.SubjectNotificationType
 import dk.shape.games.notifications.entities.Subscription
 import dk.shape.games.notifications.extensions.toActiveNotificationTypes
-import dk.shape.games.notifications.extensions.toDefaultNotificationTypes
+import dk.shape.games.notifications.extensions.toDefaultOrAllNotificationTypes
 import dk.shape.games.notifications.extensions.toIds
 import dk.shape.games.notifications.extensions.toNotificationTypes
 import dk.shape.games.notifications.presentation.viewmodels.state.StateDataSubject
@@ -59,7 +59,7 @@ data class NotificationsSettingsSubjectViewModel(
 
         setNotificationsAsync(
             notificationTypes = if (isChecked) {
-                notificationGroup.toDefaultNotificationTypes()
+                notificationGroup.toDefaultOrAllNotificationTypes()
             } else emptySet()
         )
     }


### PR DESCRIPTION
- inside notification control settings screen, toggling a subscription master switch back on should toggle all notification types, in case default notification types is empty
- this logic already works fine inside the notifications bottom sheet