### PR TITLE
Replace ModuleDiffInterface with UIDiffInterface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.3.61'
     ext.mocking_version = '1.0.6'
-    ext.uikit_version = '1.11.0'
+    ext.uikit_version = '1.18.6'
     ext.viewswitcher_version = "temp-0.4"
     ext.androidx_core_ktx_version = "1.3.0"
     ext.androidx_lifecycle_version = "2.2.0"

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationTypeViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationTypeViewModel.kt
@@ -4,12 +4,12 @@ import android.view.View
 import android.widget.CompoundButton
 import androidx.databinding.ObservableBoolean
 import androidx.databinding.ObservableField
-import dk.shape.danskespil.module.ui.ModuleDiffInterface
 import dk.shape.games.notifications.R
 import dk.shape.games.notifications.aliases.OnNotificationTypeSelected
 import dk.shape.games.notifications.bindings.awareSet
 import dk.shape.games.notifications.bindings.onChange
 import dk.shape.games.uikit.databinding.UIImage
+import dk.shape.games.uikit.utils.UIDiffInterface
 import me.tatarka.bindingcollectionadapter2.BR
 import me.tatarka.bindingcollectionadapter2.ItemBinding
 import me.tatarka.bindingcollectionadapter2.itembindings.OnItemBindClass
@@ -22,7 +22,7 @@ internal data class NotificationTypeViewModel(
     private val isDefault: Boolean,
     private val isInitialActivated: Boolean,
     private val onNotificationSelected: OnNotificationTypeSelected
-) : ModuleDiffInterface {
+) : UIDiffInterface {
 
     val isEnabled: ObservableBoolean = ObservableBoolean(true)
 
@@ -66,9 +66,7 @@ internal data class NotificationTypeViewModel(
         }
     }
 
-    override fun compareContentString() = toString()
-
-    override fun compareString() = typeId
+    override val id = typeId
 }
 
 internal fun NotificationTypeInfo.toNotificationTypeViewModel(

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/settings/NotificationTypeIconViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/settings/NotificationTypeIconViewModel.kt
@@ -1,16 +1,14 @@
 package dk.shape.games.notifications.presentation.viewmodels.settings
 
-import dk.shape.danskespil.module.ui.ModuleDiffInterface
 import dk.shape.games.notifications.aliases.SubjectNotificationType
 import dk.shape.games.notifications.bindings.toLocalUIImage
 import dk.shape.games.uikit.databinding.UIImage
+import dk.shape.games.uikit.utils.UIDiffInterface
 
 data class NotificationTypeIconViewModel(
     val icon: UIImage
-) : ModuleDiffInterface {
-    override fun compareContentString() = toString()
-
-    override fun compareString() = toString()
+) : UIDiffInterface {
+    override val id = toString()
 }
 
 internal fun Set<SubjectNotificationType>.toIconViewModels(): List<NotificationTypeIconViewModel> =

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/state/ErrorViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/state/ErrorViewModel.kt
@@ -1,9 +1,9 @@
 package dk.shape.games.notifications.presentation.viewmodels.state
 
-import dk.shape.danskespil.module.ui.ModuleDiffInterface
 import dk.shape.games.notifications.R
 import dk.shape.games.uikit.databinding.UIImage
 import dk.shape.games.uikit.databinding.UIText
+import dk.shape.games.uikit.utils.UIDiffInterface
 
 data class ErrorViewModel(
     val title: UIText = UIText.Raw.Resource(R.string.error_title),
@@ -11,8 +11,6 @@ data class ErrorViewModel(
     val description: UIText? = null,
     val icon: UIImage = UIImage.Raw.Resource(R.drawable.ic_signal_icon),
     val onRetryClick: (() -> Unit)? = null
-) : ModuleDiffInterface {
-
-    override fun compareString(): String = "ERROR_VIEW_MODEL"
-    override fun compareContentString(): String = "ERROR_VIEW_MODEL"
+) : UIDiffInterface {
+    override val id: String = "ERROR_VIEW_MODEL"
 }

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/state/LoadingViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/state/LoadingViewModel.kt
@@ -1,8 +1,5 @@
 package dk.shape.games.notifications.presentation.viewmodels.state
 
-import dk.shape.danskespil.module.ui.ModuleDiffInterface
+import dk.shape.games.uikit.utils.UIDiffInterface
 
-class LoadingViewModel : ModuleDiffInterface {
-    override fun compareString(): String = "LOADING_VIEW_MODEL"
-    override fun compareContentString(): String = "LOADING_VIEW_MODEL"
-}
+data class LoadingViewModel(override val id: String = "LOADING_VIEW_MODEL") : UIDiffInterface


### PR DESCRIPTION
The new BindingViewSwitcher supports both UIDiffInterface and ModuleDiffInterface. We are phasing out ModuleDiffInterface, so that we can get rid of the dependency from UIKit to the Modules framework. 