### PR TITLE
Notification settings functionality included to show events from the specific bet

### DIFF
--- a/notifications/src/main/java/dk/shape/games/notifications/actions/NotificationSettingsAction.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/actions/NotificationSettingsAction.kt
@@ -6,7 +6,8 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class NotificationSettingsAction(
     val betslipComponentUUID: String? = null,
-    val openedFromMyGames: Boolean = false
+    val openedFromMyGames: Boolean = false,
+    val eventIds: List<String>? = null
 ) : Action {
 
     override fun isModal() = true

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/NotificationSettingsFragment.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/NotificationSettingsFragment.kt
@@ -81,7 +81,9 @@ class NotificationSettingsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        action.getEventIds { eventIds ->
+        action.eventIds?.let { eventIds ->
+            fetchNotifications(eventIds)
+        } ?: action.getEventIds { eventIds ->
             fetchNotifications(eventIds)
         }
     }


### PR DESCRIPTION
Included optional eventIds argument to NavigationSettingsAction and use it in NavigationSettingsFragment. It was done in this way, because the `NotificationEvent.Many` holds all of the event ids for the bet