### PR TITLE
Fix/include all events for notifications from betslip

### DIFF
--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/NotificationSettingsFragment.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/NotificationSettingsFragment.kt
@@ -106,7 +106,7 @@ class NotificationSettingsFragment : Fragment() {
                         getEventNotificationsViewModels(
                             providedEventIds = providedEventIds,
                             appConfig = appConfig,
-                            includeAllEvents = action.eventIds.isNotEmpty()
+                            includeAllEvents = action.eventIds.isNotEmpty() || action.betslipComponentUUID != null
                         )
 
                     val statsNotificationViewModels =


### PR DESCRIPTION
This PR enables unsubscribed events being shown as well, when the notifications come from betslip