### PR TITLE
fix/selected type items reset on toggle switch

### DIFF
--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationSheetEventViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationSheetEventViewModel.kt
@@ -48,7 +48,6 @@ internal data class NotificationSheetEventViewModel(
     private val switchToggleHandler: (Boolean) -> Unit = { isChecked ->
         headerViewModel.activeNotificationState.awareSet(isChecked) {
             notificationTypesCollection.value {
-                resetAll()
                 onMasterActive(isChecked)
             }
             stateChangeHandler(isChecked, true)

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationSheetSubjectViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationSheetSubjectViewModel.kt
@@ -53,7 +53,6 @@ internal data class NotificationSheetSubjectViewModel(
     private val switchToggleHandler: (Boolean) -> Unit = { isChecked ->
         headerViewModel.activeNotificationState.awareSet(isChecked) {
             notificationTypesCollection.value {
-                resetAll()
                 onMasterActive(isChecked)
             }
             stateChangeHandler(isChecked, true)

--- a/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationTypeCollectionViewModel.kt
+++ b/notifications/src/main/java/dk/shape/games/notifications/presentation/viewmodels/notifications/NotificationTypeCollectionViewModel.kt
@@ -42,10 +42,6 @@ internal data class NotificationTypeCollectionViewModel(
     val hasChanges: Boolean
         get() = activatedTypeIds != selectedTypeIds
 
-    fun resetAll() {
-        selectedTypeIds = activatedTypeIds.toSet()
-    }
-
     fun allowItemInput(allowInput: Boolean) {
         notificationTypeItems.value {
             forEach {


### PR DESCRIPTION
Fixes issue [SG-2138](https://shapegames.atlassian.net/browse/SG-2138)
Removes resetting of the selectedTypeIds. After toggling the switch the selected items still reset to their default state, but the view model now holds the same correct selected item ids and because of that the change is detected and new selection settings can be saved.